### PR TITLE
Use base model

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,18 @@
 FFK-Book demonstrates a cloud-centric workflow for writing a long-form book using cooperating OpenAI agents. Research, drafting, reviewing, and updates are handled through a scripted pipeline so that every section remains stylistically consistent while facts stay current.
 FFK-Book is designed as a turnkey example for automating book writing. It integrates a research phase, prompt construction, narrative drafting, and automated reviews into a single pipeline so you can focus on editing rather than generating raw text.
 
-This repository shows how a minimal set of Python scripts can coordinate multiple GPT‑4.1 agents to produce a complete manuscript. After filling out the chapter outline and voice rules, you simply run `python run_pipeline.py` to start generating drafts. Each run stores research notes, prompts, and Markdown output under version control, making it easy to review changes and iterate.
+This repository shows how a minimal set of Python scripts can coordinate agents using the GPT‑4.1 model to produce a complete manuscript. After filling out the chapter outline and voice rules, you simply run `python run_pipeline.py` to start generating drafts. Each run stores research notes, prompts, and Markdown output under version control, making it easy to review changes and iterate.
 The repository's main purpose is to show how a small set of agent scripts can build a manuscript end to end. Edit the outline and style files, provide an API key, and run one command to start generating chapters automatically. Every generated draft appears under `drafts/` for you to inspect and refine.
 Supporting documents in `docs/` describe the style guide, QA checklist, and the detailed chapter plan used by the automation.
 This repository offers a repeatable process: fill in `config/outline.yaml`, tweak the style guide, provide your API key, and run the pipeline to generate drafts automatically.
 
 At a high level, you prepare a YAML outline listing each chapter and its short closing story, adjust the tone rules in `config/style.md`, then launch `python run_pipeline.py`. The agents research and draft each part in sequence, saving Markdown files under `drafts/` for you to review and edit. Because every step persists to plain text, you can track and improve the manuscript over time without losing context.
 
-The primary goal of this project is to showcase how cooperating GPT-4.1 agents can draft and refine a book automatically. By combining research, drafting, and review in a single script, authors keep creative control while repetitive steps run in the cloud. All data is stored in text files so progress stays transparent in version control.
+The primary goal of this project is to showcase how cooperating agents, all running GPT‑4.1, can draft and refine a book automatically. By combining research, drafting, and review in a single script, authors keep creative control while repetitive steps run in the cloud. All data is stored in text files so progress stays transparent in version control.
 
-This project serves as a working template for orchestrating multiple GPT‑4.1 agents to craft a coherent manuscript. By editing a simple YAML outline and style file, you can trigger a fully automated cycle of research, prompt creation, drafting, and review. Each run deposits new material into `drafts/` so you can track progress in version control.
+This project serves as a working template for orchestrating agents that all use GPT‑4.1 to craft a coherent manuscript. By editing a simple YAML outline and style file, you can trigger a fully automated cycle of research, prompt creation, drafting, and review. Each run deposits new material into `drafts/` so you can track progress in version control.
 
-The repository's goal is to showcase how a lightweight Python harness can coordinate different GPT‑4.1 models to produce an entire manuscript with minimal manual intervention. By running the included pipeline you can generate draft chapters, review diffs, and gradually build a polished book while keeping all configuration in simple text files. The active style rules for each agent are read from `config/style.md`; an expanded reference lives at `docs/style-guide.md` for human editors.
+The repository's goal is to showcase how a lightweight Python harness can coordinate the GPT‑4.1 model to produce an entire manuscript with minimal manual intervention. By running the included pipeline you can generate draft chapters, review diffs, and gradually build a polished book while keeping all configuration in simple text files. The active style rules for each agent are read from `config/style.md`; an expanded reference lives at `docs/style-guide.md` for human editors.
 
 In short, you edit the outline and style files, provide your API key, and let `run_pipeline.py` orchestrate research, drafting, review, and updates. Each run appends new material to `drafts/` while logging sources and diffs for transparency.
 
@@ -65,7 +65,7 @@ directories exist.
 
 ## Agent Workflow
 
-The pipeline coordinates several GPT‑4.1 agents with distinct roles. A
+The pipeline coordinates several agents, each using the GPT‑4.1 model, with distinct roles. A
 `ResearchAgent` gathers facts and citations, feeding a `PromptBuilder`
 that crafts the exact instruction set for the `DraftWriter`. Drafts are
 checked by a `ReviewerAgent`, optionally rewritten once, and then

--- a/config/openai.toml
+++ b/config/openai.toml
@@ -3,7 +3,7 @@ api_key = "sk-your-key"
 organization = ""
 
 [models]
-code_pro = "gpt-4.1-code-pro-2025-07"
-long_1M = "gpt-4.1-long-1M"
-review_64k = "gpt-4.1-review-64k"
-fast_8k = "gpt-4.1-fast-8k"
+code_pro = "gpt-4.1"
+long_1M = "gpt-4.1"
+review_64k = "gpt-4.1"
+fast_8k = "gpt-4.1"

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -42,14 +42,14 @@ Consult `voice-samples.md` for exemplar passages.
 
 ### Agent Roles and Token Budgets
 
-| Agent | 4.1 Variant | **Max output / call** | Rationale |
-|-------|-------------|-----------------------|-----------|
-| **ResearchAgent** | `gpt-4.1-long-1M` | **2 048 tokens ≈ 1 500 words** | Generates a rich fact bundle, web-sourced citations, and image descriptions while sitting well below the 8 k cap. |
-| **PromptBuilder** | `gpt-4.1-code-pro` | **400 tokens ≈ 300 words** | Emits a concise, precise drafting prompt + JSON tool calls; larger output adds no value. |
-| **DraftWriter** | `gpt-4.1-long-1M` | **4 096 tokens ≈ 3 000 words** | Delivers robust section prose yet leaves half of allowed output unused to dodge truncation. |
-| **ReviewerAgent** | `gpt-4.1-review-64k` | **1 600 tokens ≈ 1 200 words** | Produces `review.diff` plus human-readable rationale without nearing limits. |
-| **Rewriter** | `gpt-4.1-long-1M` | **4 096 tokens** | Mirrors DraftWriter to regenerate a full section if required. |
-| **UpdaterAgent** | `gpt-4.1-code-pro` | **800 tokens ≈ 600 words** | Enough for YAML/Markdown patches and a change log. |
+| Agent | Model | **Max output / call** | Rationale |
+|-------|-------|-----------------------|-----------|
+| **ResearchAgent** | `gpt-4.1` | **2 048 tokens ≈ 1 500 words** | Generates a rich fact bundle, web-sourced citations, and image descriptions while sitting well below the 8 k cap. |
+| **PromptBuilder** | `gpt-4.1` | **400 tokens ≈ 300 words** | Emits a concise, precise drafting prompt + JSON tool calls; larger output adds no value. |
+| **DraftWriter** | `gpt-4.1` | **4 096 tokens ≈ 3 000 words** | Delivers robust section prose yet leaves half of allowed output unused to dodge truncation. |
+| **ReviewerAgent** | `gpt-4.1` | **1 600 tokens ≈ 1 200 words** | Produces `review.diff` plus human-readable rationale without nearing limits. |
+| **Rewriter** | `gpt-4.1` | **4 096 tokens** | Mirrors DraftWriter to regenerate a full section if required. |
+| **UpdaterAgent** | `gpt-4.1` | **800 tokens ≈ 600 words** | Enough for YAML/Markdown patches and a change log. |
 
 Loop-guard: Reviewer issues one correction cycle → Rewriter regenerates → Reviewer performs a ≤600-token post-check and returns pass/fail summary only. Further loops need explicit user approval.
 

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -181,10 +181,10 @@ def main():
 
     DRAFTS_DIR.mkdir(exist_ok=True)
     models = cfg.get('models', {})
-    research = ResearchAgent(client, models.get('fast_8k', 'gpt-4.1-fast-8k'))
-    prompter = PromptBuilder(client, models.get('code_pro', 'gpt-4.1-code-pro-2025-07'))
-    writer = DraftWriter(client, models.get('long_1M', 'gpt-4.1-long-1M'))
-    reviewer = ReviewerAgent(client, models.get('review_64k', 'gpt-4.1-review-64k'))
+    research = ResearchAgent(client, models.get('fast_8k', 'gpt-4.1'))
+    prompter = PromptBuilder(client, models.get('code_pro', 'gpt-4.1'))
+    writer = DraftWriter(client, models.get('long_1M', 'gpt-4.1'))
+    reviewer = ReviewerAgent(client, models.get('review_64k', 'gpt-4.1'))
     updater = UpdaterAgent(client)
 
     for ch in chapters:


### PR DESCRIPTION
## Summary
- simplify agent model defaults to `gpt-4.1`
- update style guide and README to mention single base model
- adjust pipeline defaults

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6873425ea4b88325bbd39372db7b2be4